### PR TITLE
Fixed absence of index.d.ts for @types/bootstrap-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "rimraf": "2.2.8"
   },
   "dependencies": {
-    "@types/bootstrap-table": "^1.11.5",
+    "@types/bootstrap-table": "1.11.5",
     "@types/eonasdan-bootstrap-datetimepicker": "^4.17.26",
     "@types/jquery": "^2.0.49",
     "bootstrap-table": "^1.18.0"

--- a/vproker.csproj
+++ b/vproker.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Bootstrap.v3.Datetimepicker" Version="4.17.45" />
     <PackageReference Include="jQuery" Version="3.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Changed targeting version for @type/bootstrap-table from ^1.11.5 to 1.11.5. Changed version for Microsoft.EntityFrameworkCore.Tools from 2.0.1 to 2.0.3 to prevent compiler errors.